### PR TITLE
New benchmark kind `Perf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ It can be used to benchmark any text generation server that exposes an OpenAI-co
 
 ## Get started
 
+### Install
+
+If you have [cargo](https://rustup.rs/) already installed:
+```bash
+cargo install --git https://github.com/huggingface/inference-benchmarker/
+```
+
+Or download the [latest released binary](https://github.com/huggingface/inference-benchmarker/releases/latest)
+
+Or you can run docker images.
+
 ### Run a benchmark
 
 #### 1. Start an inference server
@@ -76,24 +87,13 @@ docker run --runtime nvidia --gpus all \
     --model $MODEL
 ```
 
-#### 2. Run a benchmark using Docker image
+
+#### 2. Run a benchmark
 
 ```shell
-MODEL=meta-llama/Llama-3.1-8B-Instruct
-HF_TOKEN=<your HF READ token>
-# run a benchmark to evaluate the performance of the model for chat use case
-# we mount results to the current directory
-$ docker run \
-    --rm \
-    -it \
-    --net host \
-    -v $(pwd):/opt/inference-benchmarker/results \
-    -e "HF_TOKEN=$HF_TOKEN" \
-    ghcr.io/huggingface/inference-benchmarker:latest \
-    inference-benchmarker \
-    --tokenizer-name "$MODEL" \
+inference-benchmarker
+    --tokenizer-name "meta-llama/Llama-3.1-8B-Instruct" \
     --url http://localhost:8080 \
-    --profile chat
 ```
 
 Results will be saved in JSON format in current directory.
@@ -132,16 +132,7 @@ Available modes:
 Example running a benchmark at a fixed request rates:
 
 ```shell 
-MODEL=meta-llama/Llama-3.1-8B-Instruct
-HF_TOKEN=<your HF READ token>
-$ docker run \
-    --rm \
-    -it \
-    --net host \
-    -v $(pwd):/opt/inference-benchmarker/results \
-    -e "HF_TOKEN=$HF_TOKEN" \
-    ghcr.io/huggingface/inference-benchmarker:latest \
-    inference-benchmarker \
+inference-benchmarker \
     --tokenizer-name "meta-llama/Llama-3.1-8B-Instruct" \
     --max-vus 800 \
     --duration 120s \

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ docker run --runtime nvidia --gpus all \
 inference-benchmarker
     --tokenizer-name "meta-llama/Llama-3.1-8B-Instruct" \
     --url http://localhost:8080 \
+    --profile chat
 ```
 
 Results will be saved in JSON format in current directory.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Inference Benchmarker - A terminal-based benchmarker for LLMs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rustup
+            pkg-config
+            openssl
+          ];
+
+        };
+      }
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod writers;
 
 pub struct RunConfiguration {
     pub url: Url,
+    pub api_key: String,
     pub tokenizer_name: String,
     pub profile: Option<String>,
     pub max_vus: u64,
@@ -85,7 +86,7 @@ pub async fn run(mut run_config: RunConfiguration, stop_sender: Sender<()>) -> a
         };
     let tokenizer = Arc::new(tokenizer);
     let backend = OpenAITextGenerationBackend::try_new(
-        "".to_string(),
+        run_config.api_key,
         run_config.url,
         run_config.model_name.clone(),
         tokenizer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub use crate::requests::TokenizeOptions;
 use chrono::Local;
 use crossterm::ExecutableCommand;
 use log::{debug, error, info, warn, Level, LevelFilter};
+use reqwest::Url;
 use tokenizers::{FromPretrainedParameters, Tokenizer};
 use tokio::sync::broadcast::Sender;
 use tokio::sync::Mutex;
@@ -32,7 +33,7 @@ mod table;
 mod writers;
 
 pub struct RunConfiguration {
-    pub url: String,
+    pub url: Url,
     pub tokenizer_name: String,
     pub profile: Option<String>,
     pub max_vus: u64,
@@ -85,7 +86,7 @@ pub async fn run(mut run_config: RunConfiguration, stop_sender: Sender<()>) -> a
     let tokenizer = Arc::new(tokenizer);
     let backend = OpenAITextGenerationBackend::try_new(
         "".to_string(),
-        run_config.url.clone(),
+        run_config.url,
         run_config.model_name.clone(),
         tokenizer,
         run_config.duration,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub struct RunConfiguration {
     pub duration: std::time::Duration,
     pub rates: Option<Vec<f64>>,
     pub num_rates: u64,
-    pub benchmark_kind: String,
+    pub benchmark_kind: BenchmarkKind,
     pub warmup_duration: std::time::Duration,
     pub interactive: bool,
     pub prompt_options: Option<TokenizeOptions>,
@@ -96,12 +96,7 @@ pub async fn run(mut run_config: RunConfiguration, stop_sender: Sender<()>) -> a
     let config = BenchmarkConfig {
         max_vus: run_config.max_vus,
         duration: run_config.duration,
-        benchmark_kind: match run_config.benchmark_kind.to_lowercase().as_str() {
-            "throughput" => BenchmarkKind::Throughput,
-            "sweep" => BenchmarkKind::Sweep,
-            "rate" => BenchmarkKind::Rate,
-            _ => BenchmarkKind::Sweep,
-        },
+        benchmark_kind: run_config.benchmark_kind,
         warmup_duration: run_config.warmup_duration,
         rates: run_config.rates,
         num_rates: run_config.num_rates,
@@ -120,7 +115,7 @@ pub async fn run(mut run_config: RunConfiguration, stop_sender: Sender<()>) -> a
         let target = Box::new(File::create("log.txt").expect("Can't create file"));
         env_logger::Builder::new()
             .target(env_logger::Target::Pipe(target))
-            .filter(Some("inference_benchmarker"), LevelFilter::Debug)
+            .filter(Some("inference_benchmarker"), LevelFilter::Info)
             .format(|buf, record| {
                 writeln!(
                     buf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,10 @@ struct Args {
     #[clap(default_value = "http://localhost:8000", short, long, env)]
     url: Url,
 
+    /// The api key send to the [`url`] as Header "Authorization: Bearer {API_KEY}".
+    #[clap(default_value = "", short, long, env)]
+    api_key: String,
+
     /// Disable console UI
     #[clap(short, long, env)]
     no_console: bool,
@@ -203,7 +207,8 @@ async fn main() {
         .run_id
         .unwrap_or(uuid::Uuid::new_v4().to_string()[..7].to_string());
     let run_config = RunConfiguration {
-        url: args.url.clone(),
+        url: args.url,
+        api_key: args.api_key,
         profile: args.profile.clone(),
         tokenizer_name: args.tokenizer_name.clone(),
         max_vus: args.max_vus,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,8 @@ struct Args {
     warmup: Duration,
     /// The URL of the backend to benchmark. Must be compatible with OpenAI Message API
     #[clap(default_value = "http://localhost:8000", short, long, env)]
-    #[arg(value_parser = parse_url)]
-    url: String,
+    url: Url,
+
     /// Disable console UI
     #[clap(short, long, env)]
     no_console: bool,
@@ -113,13 +113,6 @@ struct Args {
 
 fn parse_duration(s: &str) -> Result<Duration, Error> {
     humantime::parse_duration(s).map_err(|_| Error::new(InvalidValue))
-}
-
-fn parse_url(s: &str) -> Result<String, Error> {
-    match Url::parse(s) {
-        Ok(_) => Ok(s.to_string()),
-        Err(_) => Err(Error::new(InvalidValue)),
-    }
 }
 
 fn parse_key_val(s: &str) -> Result<HashMap<String, String>, Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,7 @@ async fn main() {
     let stop_sender_clone = stop_sender.clone();
     // get HF token
     let token_env_key = "HF_TOKEN".to_string();
-    let cache = hf_hub::Cache::default();
+    let cache = hf_hub::Cache::from_env();
     let hf_token = match std::env::var(token_env_key).ok() {
         Some(token) => Some(token),
         None => cache.token(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::error::ErrorKind::InvalidValue;
 use clap::{ArgGroup, Error, Parser};
-use inference_benchmarker::{run, RunConfiguration, TokenizeOptions};
+use inference_benchmarker::{run, BenchmarkKind, RunConfiguration, TokenizeOptions};
 use log::{debug, error};
 use reqwest::Url;
 use std::collections::HashMap;
@@ -37,10 +37,17 @@ struct Args {
     #[clap(long, env, group = "group_profile")]
     profile: Option<String>,
     /// The kind of benchmark to run (throughput, sweep, optimum)
-    #[clap(default_value = "sweep", short, long, env, group = "group_manual")]
-    benchmark_kind: String,
+    #[clap(
+        default_value = "sweep",
+        short,
+        long,
+        env,
+        group = "group_manual",
+        value_enum
+    )]
+    benchmark_kind: BenchmarkKind,
     /// The duration of the prewarm step ran before the benchmark to warm up the backend (JIT, caches, etc.)
-    #[clap(default_value = "30s", short, long, env, group = "group_manual")]
+    #[clap(default_value = "1s", short, long, env, group = "group_manual")]
     #[arg(value_parser = parse_duration)]
     warmup: Duration,
     /// The URL of the backend to benchmark. Must be compatible with OpenAI Message API
@@ -215,7 +222,7 @@ async fn main() {
         duration: args.duration,
         rates: args.rates,
         num_rates: args.num_rates,
-        benchmark_kind: args.benchmark_kind.clone(),
+        benchmark_kind: args.benchmark_kind,
         warmup_duration: args.warmup,
         interactive: !args.no_console,
         prompt_options: args.prompt_options.clone(),

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,4 +1,4 @@
-use crate::{RunConfiguration, TokenizeOptions};
+use crate::{BenchmarkKind, RunConfiguration, TokenizeOptions};
 use std::string::ToString;
 
 pub fn apply_profile(
@@ -11,7 +11,7 @@ pub fn apply_profile(
             duration: std::time::Duration::from_secs(120),
             rates: None,
             num_rates: 10,
-            benchmark_kind: "sweep".to_string(),
+            benchmark_kind: BenchmarkKind::Sweep,
             warmup_duration: std::time::Duration::from_secs(30),
             prompt_options: Some(TokenizeOptions {
                 num_tokens: Some(200),
@@ -40,7 +40,7 @@ pub fn apply_profile(
                 duration: std::time::Duration::from_secs(120),
                 rates: None,
                 num_rates: 10,
-                benchmark_kind: "sweep".to_string(),
+                benchmark_kind: BenchmarkKind::Sweep,
                 warmup_duration: std::time::Duration::from_secs(30),
                 prompt_options: None, // use prompts from dataset
                 decode_options: Some(TokenizeOptions {
@@ -62,7 +62,7 @@ pub fn apply_profile(
                 duration: std::time::Duration::from_secs(120),
                 rates: None,
                 num_rates: 10,
-                benchmark_kind: "sweep".to_string(),
+                benchmark_kind: BenchmarkKind::Sweep,
                 warmup_duration: std::time::Duration::from_secs(30),
                 prompt_options: Some(TokenizeOptions {
                     num_tokens: Some(4096),
@@ -91,7 +91,7 @@ pub fn apply_profile(
                 duration: std::time::Duration::from_secs(120),
                 rates: None,
                 num_rates: 10,
-                benchmark_kind: "sweep".to_string(),
+                benchmark_kind: BenchmarkKind::Sweep,
                 warmup_duration: std::time::Duration::from_secs(30),
                 prompt_options: Some(TokenizeOptions {
                     num_tokens: Some(10000),

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -547,7 +547,7 @@ impl ConversationTextRequestGenerator {
         filename: String,
         hf_token: Option<String>,
     ) -> anyhow::Result<PathBuf> {
-        let api = ApiBuilder::new().with_token(hf_token).build()?;
+        let api = ApiBuilder::from_env().with_token(hf_token).build()?;
         let repo = api.dataset(repo_name);
         let dataset = repo.get(&filename)?;
         Ok(dataset)

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -6,6 +6,7 @@ use log::{debug, error, info, trace, warn};
 use rand_distr::Distribution;
 use rayon::iter::split;
 use rayon::prelude::*;
+use reqwest::Url;
 use reqwest_eventsource::{Error, Event, EventSource};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -58,7 +59,7 @@ impl Clone for Box<dyn TextGenerationBackend + Send + Sync> {
 #[derive(Debug, Clone)]
 pub struct OpenAITextGenerationBackend {
     pub api_key: String,
-    pub base_url: String,
+    pub base_url: Url,
     pub model_name: String,
     pub client: reqwest::Client,
     pub tokenizer: Arc<Tokenizer>,
@@ -101,7 +102,7 @@ pub struct OpenAITextGenerationRequest {
 impl OpenAITextGenerationBackend {
     pub fn try_new(
         api_key: String,
-        base_url: String,
+        base_url: Url,
         model_name: String,
         tokenizer: Arc<Tokenizer>,
         timeout: time::Duration,
@@ -829,7 +830,7 @@ mod tests {
                 w.write_all(b"data: [DONE]\n\n")
             })
             .create_async().await;
-        let url = s.url();
+        let url = s.url().parse().unwrap();
         let tokenizer = Arc::new(Tokenizer::from_pretrained("gpt2", None).unwrap());
         let backend = OpenAITextGenerationBackend::try_new(
             "".to_string(),
@@ -890,7 +891,7 @@ mod tests {
                 w.write_all(b"data: [DONE]\n\n")
             })
             .create_async().await;
-        let url = s.url();
+        let url = s.url().parse().unwrap();
         let tokenizer = Arc::new(Tokenizer::from_pretrained("gpt2", None).unwrap());
         let backend = OpenAITextGenerationBackend::try_new(
             "".to_string(),
@@ -975,7 +976,7 @@ mod tests {
             .with_chunked_body(|w| w.write_all(b"data: {\"error\": \"Internal server error\"}\n\n"))
             .create_async()
             .await;
-        let url = s.url();
+        let url = s.url().parse().unwrap();
         let tokenizer = Arc::new(Tokenizer::from_pretrained("gpt2", None).unwrap());
         let backend = OpenAITextGenerationBackend::try_new(
             "".to_string(),
@@ -1021,7 +1022,7 @@ mod tests {
             .with_chunked_body(|w| w.write_all(b"this is wrong\n\n"))
             .create_async()
             .await;
-        let url = s.url();
+        let url = s.url().parse().unwrap();
         let tokenizer = Arc::new(Tokenizer::from_pretrained("gpt2", None).unwrap());
         let backend = OpenAITextGenerationBackend::try_new(
             "".to_string(),
@@ -1067,7 +1068,7 @@ mod tests {
             .with_chunked_body(|w| w.write_all(b"data: {\"foo\": \"bar\"}\n\n"))
             .create_async()
             .await;
-        let url = s.url();
+        let url = s.url().parse().unwrap();
         let tokenizer = Arc::new(Tokenizer::from_pretrained("gpt2", None).unwrap());
         let backend = OpenAITextGenerationBackend::try_new(
             "".to_string(),
@@ -1117,7 +1118,7 @@ mod tests {
                 w.write_all(b"data: [DONE]\n\n")
             })
             .create_async().await;
-        let url = s.url();
+        let url = s.url().parse().unwrap();
         let tokenizer = Arc::new(Tokenizer::from_pretrained("gpt2", None).unwrap());
         let backend = OpenAITextGenerationBackend::try_new(
             "".to_string(),

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -154,6 +154,7 @@ impl TextGenerationBackend for OpenAITextGenerationBackend {
             )
             .json(&serde_json::json!(body))
             .timeout(self.timeout);
+        info!("Sending request");
         // start timer
         aggregated_response.start();
         let mut es = EventSource::new(req).unwrap();
@@ -217,6 +218,7 @@ impl TextGenerationBackend for OpenAITextGenerationBackend {
                     };
                 }
                 Err(e) => {
+                    error!("Got SSE error : {e}");
                     match e {
                         Error::Utf8(_) => {
                             aggregated_response.fail();

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -129,7 +129,9 @@ impl TextGenerationBackend for OpenAITextGenerationBackend {
         request: Arc<TextGenerationRequest>,
         sender: Sender<TextGenerationAggregatedResponse>,
     ) {
-        let url = format!("{base_url}/v1/chat/completions", base_url = self.base_url);
+        let mut url = self.base_url.clone();
+        url.set_path("/v1/chat/completions");
+        // let url = format!("{base_url}", base_url = self.base_url);
         let mut aggregated_response = TextGenerationAggregatedResponse::new(request.clone());
         let messages = vec![OpenAITextGenerationMessage {
             role: "user".to_string(),

--- a/src/results.rs
+++ b/src/results.rs
@@ -241,7 +241,7 @@ impl BenchmarkResults {
     /// Calculate the quantile of a given data set using interpolation method
     /// Results are similar to `numpy.percentile`
     fn quantile_duration(&self, mut data: Vec<Duration>, quantile: f64) -> anyhow::Result<f64> {
-        if self.is_ready() {
+        if self.is_ready() && data.len() > 1 {
             data.sort();
             let i = (quantile * (data.len() - 1) as f64).floor();
             let delta = (data.len() - 1) as f64 * quantile - i;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -232,7 +232,7 @@ mod tests {
                 w.write_all(b"data: [DONE]\n\n")
             })
             .create_async().await;
-        let url = s.url();
+        let url = s.url().parse().unwrap();
         let tokenizer = Arc::new(Tokenizer::from_pretrained("gpt2", None).unwrap());
         let backend = OpenAITextGenerationBackend::try_new(
             "".to_string(),


### PR DESCRIPTION
Took the opportunity to remove the string intermediate ( to avoid missing some place to update the enum variant and better CLI errors) 