### PR TITLE
K8s deploy model, fix HOME and benchmark parameter

### DIFF
--- a/extra/k8s/inference-benchmarker/templates/vllm.yaml
+++ b/extra/k8s/inference-benchmarker/templates/vllm.yaml
@@ -43,6 +43,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "inference-benchmarker.fullname" . }}-hf-token
                   key: HF_TOKEN
+            - name: HOME
+              value: /tmp
           args:
             - "--model"
             - "{{ .Values.model_id }}"

--- a/extra/k8s/inference-benchmarker/values.yaml
+++ b/extra/k8s/inference-benchmarker/values.yaml
@@ -3,11 +3,11 @@ nameOverride: ""
 fullnameOverride: ""
 
 hf_token: ""
-model_id: "meta-llama/Llama-3.1-8B-Instruct"
-server: tgi
+model_id: "microsoft/Phi-3-mini-4k-instruct"
+server: vllm
 
 tgi:
-  enabled: true
+  enabled: false
   extra_args:
     - "--max-concurrent-requests"
     - "512"
@@ -28,7 +28,7 @@ tgi:
   affinity: { }
 
 vllm:
-  enabled: false
+  enabled: true
   extra_args:
   image:
     repository: vllm/vllm-openai
@@ -50,7 +50,6 @@ benchmark:
   extra_args:
     - "--profile"
     - "chat"
-    - "800"
   image:
     repository: ghcr.io/huggingface/inference-benchmarker
     pullPolicy: IfNotPresent


### PR DESCRIPTION
* Deploy the "microsoft/Phi-3-mini-4k-instruct" model from Hugging Face (lightweight and includes a tokenizer)
* Fix the `HOME` directory to `/tmp`
* Fix benchmark launch parameters.
Fix #30 and #31 