### PR TITLE
Append the endpoint path to the base_url instead of replacing the path

### DIFF
--- a/src/requests.rs
+++ b/src/requests.rs
@@ -130,8 +130,7 @@ impl TextGenerationBackend for OpenAITextGenerationBackend {
         sender: Sender<TextGenerationAggregatedResponse>,
     ) {
         let mut url = self.base_url.clone();
-        url.set_path("/v1/chat/completions");
-        // let url = format!("{base_url}", base_url = self.base_url);
+        url.set_path(&format!("{}/v1/chat/completions", url.path().trim_end_matches('/')));
         let mut aggregated_response = TextGenerationAggregatedResponse::new(request.clone());
         let messages = vec![OpenAITextGenerationMessage {
             role: "user".to_string(),


### PR DESCRIPTION
I'm testing the tool to benchmark an endpoint that is OpenAI-compatible but where the routes are behind a path, for example `https://myendpoint.com/api/openai_compat/v1/chat/completions`.

Currently, when I pass the url `https://myendpoint.com/api/openai_compat` in the CLI, the endpoint path overrides the existing path, so the tool calls `https://myendpoint.com/v1/chat/completions` which is not available.

This change appends the endpoint path to the base url instead of replacing it, enabling my use case.
