### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,16 +14,16 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4.4.1
+        uses: rlespinasse/github-slug-action@102b1a064a9b145e56556e22b18b19c624538d94  # v4.4.1
       - name: Initialize Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
           install: true
           buildkitd-config: /tmp/buildkitd.toml
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         if: ${{ github.event_name == 'pull_request' }}
         id: meta-pr
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: |
             ghcr.io/huggingface/inference-benchmarker
@@ -42,7 +42,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         if: ${{ github.event_name != 'pull_request' }}
         id: meta
-        uses: docker/metadata-action@v4.3.0
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96  # v4.3.0
         with:
           flavor: |
             latest=auto
@@ -55,7 +55,7 @@ jobs:
             type=raw,value=sha-${{ env.GITHUB_SHA_SHORT }}
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
@@ -75,7 +75,7 @@ jobs:
           docker rm -f extract
       - name: Upload binary
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: inference-benchmarker_x86_64
           path: ${{ github.workspace }}/inference-benchmarker

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,8 +13,8 @@ jobs:
     runs-on:
       group: aws-general-8-plus
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: nightly
           components: rustfmt
@@ -25,13 +25,13 @@ jobs:
     runs-on:
       group: aws-general-8-plus
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
           components: clippy
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         env:
           cache-name: cache-dependencies
         with:
@@ -56,12 +56,12 @@ jobs:
     runs-on:
       group: aws-general-8-plus
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: stable
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         env:
           cache-name: cache-dependencies-test
         with:

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -9,10 +9,10 @@ jobs:
       group: aws-general-8-plus
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0
     - name: Secret Scanning
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b  # main
       with:
         extra_args: --exclude-globs='test_data/.*' --results=verified,unknown --exclude-detectors=postgres


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `rust.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `rust.yaml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `rust.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `rust.yaml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `rust.yaml` | `actions/cache` | `v4` | `v4` | `0057852bfaa8…` |
| `rust.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `rust.yaml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `rust.yaml` | `actions/cache` | `v4` | `v4` | `0057852bfaa8…` |
| `build.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `build.yaml` | `rlespinasse/github-slug-action` | `v4.4.1` | `v4.4.1` | `102b1a064a9b…` |
| `build.yaml` | `docker/setup-buildx-action` | `v3` | `v3` | `8d2750c68a42…` |
| `build.yaml` | `docker/login-action` | `v3` | `v3` | `c94ce9fb4685…` |
| `build.yaml` | `docker/metadata-action` | `v5` | `v5` | `c299e40c6544…` |
| `build.yaml` | `docker/metadata-action` | `v4.3.0` | `v4.3.0` | `507c2f2dc502…` |
| `build.yaml` | `docker/build-push-action` | `v4` | `v4` | `0a97817b6ade…` |
| `build.yaml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `trufflehog.yaml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `trufflehog.yaml` | `trufflesecurity/trufflehog` | `main` | `main` | `6bd2d14f7a4b…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#150