### PR TITLE
fix: prevent panic in quantile computation with single response

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -241,19 +241,17 @@ impl BenchmarkResults {
     /// Calculate the quantile of a given data set using interpolation method
     /// Results are similar to `numpy.percentile`
     fn quantile_duration(&self, mut data: Vec<Duration>, quantile: f64) -> anyhow::Result<f64> {
-        if self.is_ready() {
-            data.sort();
-            let i = (quantile * (data.len() - 1) as f64).floor();
-            let delta = (data.len() - 1) as f64 * quantile - i;
-            if i as usize >= data.len() {
-                return Err(anyhow::anyhow!(NoResponses));
-            }
-            let quantile = (1. - delta) * data[i as usize].as_secs_f64()
-                + delta * data[i as usize + 1].as_secs_f64();
-            Ok(quantile)
-        } else {
-            Err(anyhow::anyhow!(NoResponses))
+        if !self.is_ready() || data.is_empty() {
+            return Err(anyhow::anyhow!(NoResponses));
         }
+        data.sort();
+        let i = (quantile * (data.len() - 1) as f64).floor() as usize;
+        let delta = (data.len() - 1) as f64 * quantile - i as f64;
+        if i + 1 >= data.len() {
+            return Ok(data[i].as_secs_f64());
+        }
+        let quantile = (1. - delta) * data[i].as_secs_f64() + delta * data[i + 1].as_secs_f64();
+        Ok(quantile)
     }
 }
 
@@ -440,6 +438,43 @@ mod test {
         assert_eq!(
             results.time_to_first_token_percentile(0.5).unwrap(),
             Duration::from_millis(850)
+        );
+    }
+
+    #[test]
+    fn test_percentile_with_single_successful_response() {
+        let request = Arc::from(TextGenerationRequest {
+            id: None,
+            prompt: "test".to_string(),
+            num_prompt_tokens: 10,
+            num_decode_tokens: None,
+        });
+        let mut response = TextGenerationAggregatedResponse::new(request);
+        response.start_time = Some(tokio::time::Instant::now());
+        response.end_time =
+            Some(tokio::time::Instant::now() + tokio::time::Duration::from_millis(100));
+        response.num_generated_tokens = 100;
+        response.failed = false;
+        response.times_to_tokens = vec![Duration::from_millis(100)];
+
+        let mut results = BenchmarkResults::new(
+            "test".to_string(),
+            ExecutorType::ConstantArrivalRate,
+            ExecutorConfig {
+                max_vus: 0,
+                duration: Default::default(),
+                rate: None,
+            },
+        );
+        results.add_response(response);
+
+        assert_eq!(
+            results.time_to_first_token_percentile(0.5).unwrap(),
+            Duration::from_millis(100)
+        );
+        assert_eq!(
+            results.time_to_first_token_percentile(0.9).unwrap(),
+            Duration::from_millis(100)
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #36.

`quantile_duration` at `src/results.rs:252` panicked with `index out of bounds: the len is 1 but the index is 1` when only one successful response had been collected for a given rate — common at the very low rates from the issue (`0.016`, `0.1` req/s), where the run is short enough that a percentile bucket ends up with a single sample.

Root cause: the existing guard only checked `i >= data.len()`, but the interpolation also reads `data[i+1]`. With `data.len() == 1`, `i = 0` and `delta = 0`, so the second term contributes nothing — but is still evaluated, hence the panic.

Fix: bail out early on empty data, and when `i + 1 >= data.len()` return `data[i]` directly (delta is 0 in that case, so no interpolation is needed).

Added a regression test exercising the single-response path.

## End-to-end verification

Built this PR and ran it against a live HF Inference Endpoint (`HuggingFaceTB/SmolLM2-1.7B-Instruct` on `nvidia-l4 x1`, vLLM) with the exact low-rate shape that triggers the bug — `--rates 0.1 --duration 15s` — forcing a single-sample percentile bucket:

```
│ Benchmark          │ QPS        │ E2E Latency (avg) │ TTFT (avg) │ ITL (avg) │ Successful Requests │
│ warmup             │ 1.14 req/s │ 0.87 sec          │ 171.76 ms  │ 14.22 ms  │ 6/6                 │
│ constant@0.10req/s │ 0.93 req/s │ 1.07 sec          │ 127.30 ms  │ 14.28 ms  │ 1/1                 │
```

The `1/1` bucket is the previously-panicking case. Resulting percentiles all return the single sample's value (no interpolation):

```json
"e2e_latency_ms":         {"p50": 1071.396, "p90": 1071.396, "p99": 1071.396, "avg": 1071.396},
"inter_token_latency_ms": {"p50":   14.279, "p90":   14.279, "p99":   14.279, "avg":   14.279}
```

On `main` this run would have aborted mid-benchmark with the original panic; with the fix, the run completes and the JSON report is written.