### PR TITLE
fix(dashboard): keep numeric dtype so columns sort numerically

### DIFF
--- a/extra/dashboard/app.py
+++ b/extra/dashboard/app.py
@@ -77,7 +77,7 @@ def run(from_results_dir, datasource, port):
              'token_throughput_secs']]
         for metric in ['inter_token_latency_ms_p90', 'time_to_first_token_ms_p90', 'e2e_latency_ms_p90',
                        'token_throughput_secs']:
-            data[metric] = data[metric].apply(lambda x: f"{x:.2f}")
+            data[metric] = pd.to_numeric(data[metric], errors='coerce').round(2)
         data = data.rename(
             columns=column_mappings)
         return data


### PR DESCRIPTION
## Summary

Fixes #24.

The summary table was coercing metrics to formatted strings (`f"{x:.2f}"`), which made the Gradio DataFrame sort them lexicographically — e.g. `114.42, 1785.64, 181.58, 1816.62, 182.33` instead of the correct numerical order.

Using `pd.to_numeric(...).round(2)` keeps the underlying dtype numeric, so Gradio sorts by value while still showing two-decimal precision.