### PR TITLE
fix(k8s): make vllm chart writable under OpenShift restricted SCC

### DIFF
--- a/extra/k8s/inference-benchmarker/templates/vllm.yaml
+++ b/extra/k8s/inference-benchmarker/templates/vllm.yaml
@@ -43,6 +43,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "inference-benchmarker.fullname" . }}-hf-token
                   key: HF_TOKEN
+            - name: HOME
+              value: /data
           args:
             - "--model"
             - "{{ .Values.model_id }}"
@@ -66,12 +68,16 @@ spec:
           volumeMounts:
             - name: shm
               mountPath: /dev/shm
+            - name: cache
+              mountPath: /data
       terminationGracePeriodSeconds: 10
       volumes:
         - name: shm
           emptyDir:
             medium: Memory
             sizeLimit: 1Gi
+        - name: cache
+          emptyDir: {}
       {{- with .Values.vllm.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary

Fixes #30.

Under OpenShift's restricted SCC, pods run with a random UID and no writable `$HOME`. vLLM defaults to `~/.cache` for model downloads, which resolves to `/.cache` (root dir) and fails with `PermissionError: [Errno 13] Permission denied: '/.cache'`.

- Set `HOME=/data` on the vLLM container.
- Mount a writable `emptyDir` at `/data` so HF Hub, vLLM, Triton, and PyTorch caches all land in a path the random UID can write to.

`helm template` renders cleanly; no changes to values.yaml defaults.